### PR TITLE
Add new tools RomBrowser and E32Explorer

### DIFF
--- a/index.md
+++ b/index.md
@@ -24,6 +24,8 @@ _Work in Progress by [@loociano](https://github.com/loociano), last update on Ju
 * [NGEmu](https://github.com/NGEmu/NGEmu) by [@tambry](https://github.com/tambry): HLE N-Gage emulator written in C++ for Windows
 * [Rusty Starship](https://gitlab.com/tambre/rusty-starship) by [@tambre](https://gitlab.com/tambre): Collection of tools
 * [Deark](http://entropymine.com/deark/) to extract and convert images to `.png` from an multibitmap `.mbm` or `.aif`
+* [RomBrowser](https://github.com/Florin9doi/rombrowser) by [@Florin9doi](https://github.com/Florin9doi): to display the content of a dump of the rom.
+* [E32Explorer](https://github.com/mrRosset/E32Explorer) by [@mrRosset](https://github.com/mrRosset): to read E32Image and partially read TRomImage
 * S60 SDK Utilities:
   * `bmconv` to extract images from a multibitmap `.mbm`
   * `petran` to read E32Image


### PR DESCRIPTION
Hi, nice website
It's great to see you are creating such a compilation of docs.

I felt like this 2 tools could be added to the list as they are a big help (at least to me) when I'm reversing Symbian applications and Symbian rom dlls.

* RomBrowser works with dumps created with the dumper from Rusty Starship but also with the one provided by THC. [Example](http://i.imgur.com/4Siyhek.png)
* For E32Explorer, I tend to prefer a visual display compared to petran and it can partially show parts of an TRomImage which is useful since petran doesn't work with them and IDA Pro also has some problems with them.